### PR TITLE
Fixes infinite loop error in cli_crawler 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ set(HTTP_CRAWLER_FILES
 set(MISC_FILES
 	src/misc/stepTimer.cpp
 	src/misc/readLinesFromFile.cpp
+	src/misc/splitByDate.cpp
 )
 
 set(TEST_FILES

--- a/src/cli/main_crawlerParser.cpp
+++ b/src/cli/main_crawlerParser.cpp
@@ -55,6 +55,8 @@ int main(int argc, char** argv)
 		("comment-list-json", "Flag for exporting the list of comments (json).")
 
 		("keep-raw-talk-pages", "Flag for keeping the raw crawled talk pages.")
+    
+        ("split-by-date", "Flag for splitting talk pages into two seperate files by some date")
 		// misc
 		("show-timings", "Show the timings for the different steps.")
 		;
@@ -85,6 +87,7 @@ int main(int argc, char** argv)
 
 		AdditionalCrawlerOptions crawler_options;
 		crawler_options.keep_raw_talk_pages = options.count("keep-raw-talk-pages");
+        crawler_options.split_by_date = options.count("split-by-date"); 
 		crawler_options.status_callback = [](const std::string& msg) { std::cout << msg << std::endl; };
 		crawling(titles, output_folder, formats, crawler_options);
 	}

--- a/src/cli/main_crawlerParser.cpp
+++ b/src/cli/main_crawlerParser.cpp
@@ -11,6 +11,7 @@
 
 #include "../output/outputHelpers.h"
 #include "../misc/readLinesFromFile.h"
+#include "../misc/splitByDate.h"
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/foreach.hpp>
 
@@ -94,9 +95,9 @@ int main(int argc, char** argv)
             titleNDates = read_lines_dates_from_file(input_file);
             
             // then just get the titles from the titles and dates map
-            std::pair<std::string,std:string> titleWithDate;
+            std::pair<std::string,std::string> titleWithDate;
             BOOST_FOREACH(titleWithDate, titleNDates) {
-                titles.push_back(me.first);
+                titles.push_back(titleWithDate.first);
         }
             
 		AdditionalCrawlerOptions crawler_options;
@@ -104,15 +105,14 @@ int main(int argc, char** argv)
         crawler_options.split_by_date = options.count("split-by-date"); 
 		crawler_options.status_callback = [](const std::string& msg) { std::cout << msg << std::endl; };
             
-        if
 		crawling(titles, titleNDates, output_folder, formats, crawler_options);
-	}
-	catch(const std::invalid_argument& e) {
+        }
+    } catch (const std::invalid_argument& e) {
 		std::cerr << "ABORTING. An argument error appeared: " << e.what() << std::endl << std::endl;
 		std::cerr << "Try -h or --help for more information" << std::endl;
 		return 1;
 	}
-	catch(const std::exception& e) {
+	catch (const std::exception& e) {
 		std::cerr << "ABORTING. The application terminated with an exception: " << std::endl << e.what() << std::endl << std::endl;
 		return 1;
 	}

--- a/src/cli/main_crawlerParser.cpp
+++ b/src/cli/main_crawlerParser.cpp
@@ -89,7 +89,6 @@ int main(int argc, char** argv)
         std::map<std::string, std::string> titleNDates;
         if(!options.count("split-by-date")){
             titles = read_lines_from_file(input_file);
-            
         }
         else{
             titleNDates = read_lines_dates_from_file(input_file);
@@ -98,15 +97,14 @@ int main(int argc, char** argv)
             std::pair<std::string,std::string> titleWithDate;
             BOOST_FOREACH(titleWithDate, titleNDates) {
                 titles.push_back(titleWithDate.first);
+            }
         }
-            
 		AdditionalCrawlerOptions crawler_options;
 		crawler_options.keep_raw_talk_pages = options.count("keep-raw-talk-pages");
         crawler_options.split_by_date = options.count("split-by-date"); 
 		crawler_options.status_callback = [](const std::string& msg) { std::cout << msg << std::endl; };
-            
 		crawling(titles, titleNDates, output_folder, formats, crawler_options);
-        }
+        
     } catch (const std::invalid_argument& e) {
 		std::cerr << "ABORTING. An argument error appeared: " << e.what() << std::endl << std::endl;
 		std::cerr << "Try -h or --help for more information" << std::endl;

--- a/src/cli/main_crawlerParser.cpp
+++ b/src/cli/main_crawlerParser.cpp
@@ -12,6 +12,7 @@
 #include "../output/outputHelpers.h"
 #include "../misc/readLinesFromFile.h"
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/foreach.hpp>
 
 using namespace Grawitas;
 using namespace std;
@@ -82,14 +83,29 @@ int main(int argc, char** argv)
 		std::ifstream input_file(input_file_path);
 		if (!input_file.is_open())
 			throw std::invalid_argument("File containing article titles could not be opened.");
-
-		const auto titles = read_lines_from_file(input_file);
-
+        
+        std::vector<std::string> titles;
+        std::map<std::string, std::string> titleNDates;
+        if(!options.count("split-by-date")){
+            titles = read_lines_from_file(input_file);
+            
+        }
+        else{
+            titleNDates = read_lines_dates_from_file(input_file);
+            
+            // then just get the titles from the titles and dates map
+            std::pair<std::string,std:string> titleWithDate;
+            BOOST_FOREACH(titleWithDate, titleNDates) {
+                titles.push_back(me.first);
+        }
+            
 		AdditionalCrawlerOptions crawler_options;
 		crawler_options.keep_raw_talk_pages = options.count("keep-raw-talk-pages");
         crawler_options.split_by_date = options.count("split-by-date"); 
 		crawler_options.status_callback = [](const std::string& msg) { std::cout << msg << std::endl; };
-		crawling(titles, output_folder, formats, crawler_options);
+            
+        if
+		crawling(titles, titleNDates, output_folder, formats, crawler_options);
 	}
 	catch(const std::invalid_argument& e) {
 		std::cerr << "ABORTING. An argument error appeared: " << e.what() << std::endl << std::endl;

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -76,7 +76,7 @@ namespace {
 			if(boost::to_lower_copy(title.substr(0,5)) == "talk:")
 				title = title.substr(5);
             
-            // removes any underscores
+            // removes any underscores used as spaces in page titles
             std::string delim = "_";
             auto end = title.find(delim);
             if (end != std::string::npos)
@@ -104,7 +104,6 @@ namespace Grawitas {
 			for(std::size_t i = 0; i < N_PAGES_PER_REQUEST; i++)
 			{
 				auto& page = page_progress[i % page_progress.size()];
-                //std::cout << "Page:" << page.first << "\n";
 				if(page.second == 0)
 					current_titles.push_back("Talk:" + page.first);
 				else

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -85,6 +85,33 @@ namespace {
                 std::replace(title.begin(), title.end(), '_', ' ');
 		}
 	}
+    void sanitize_titles(std::map<std::string, std::string>& titlesNDates)
+    {
+        std::map<std::string, std::string> newTitlesNDates;
+        for (auto& titleNDate : titlesNDates ) {
+            auto title = titleNDate.first;
+            auto date = titleNDate.second;
+            if(title.substr(0,7) == "http://")
+                throw std::invalid_argument("It seems like the provided articles are URLs. In newer versions of Grawitas you should simply provide the titles of the articles in the input file.");
+
+            if(boost::to_lower_copy(title) == "talk:")
+                title = title.substr(5);
+            
+            
+            // removes any underscores used as spaces in page titles
+            std::string delim = "_";
+            auto end = title.find(delim);
+            if (end != std::string::npos)
+                std::replace(title.begin(), title.end(), '_', ' ');
+            
+            std::pair<std::string, std::string> newTitleNDate = std::make_pair(title, date);
+            newTitlesNDates.insert(newTitleNDate);
+            
+        }
+        // replaces titlesNDates with sanitised map of newTitlesNDates
+        newTitlesNDates.swap(titlesNDates);
+    }
+
 
 
 
@@ -95,7 +122,7 @@ namespace Grawitas {
 	{
                 
 		::sanitize_titles(article_titles);
-
+        ::sanitize_titles(titleNDates);
 		// initialization of data structures
 		std::map<std::string, std::vector<Grawitas::Comment>> partially_parsed_articles_map;
 		std::deque<std::pair<std::string, int>> page_progress;
@@ -194,10 +221,10 @@ namespace Grawitas {
                         catch (const std::out_of_range&) {
                             dateToSplit = "01/01/2000";
                         }
+                        options.status_callback("Finished all archives of '" + result.title + " after" + dateToSplit + "'. Exporting results.");
                         export_finished_pages(output_folder, formats, result.title, parsed_talk_page, dateToSplit);
                     }
                     else {
-                        
                         export_finished_talk_page(output_folder, formats, result.title, parsed_talk_page);
                     }
                     

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -60,6 +60,7 @@ namespace {
 		std::map<Grawitas::Format, std::string> formats_with_paths;
 		for (const auto& format : formats)
 			formats_with_paths.insert({ format, output_folder + "/" + title_filename + Grawitas::FormatFileExtensions.at(format) });
+        
 
 		Grawitas::output_in_formats_to_files(formats_with_paths, parsed_talk_page, {"id", "parent_id", "user", "date", "section", "text"});
 	}
@@ -92,8 +93,7 @@ namespace {
 namespace Grawitas {
 	void crawling(std::vector<std::string> article_titles, std::map<std::string, std::string> titleNDates, const std::string& output_folder, const std::set<Grawitas::Format> formats, AdditionalCrawlerOptions options)
 	{
-        
-        
+                
 		::sanitize_titles(article_titles);
 
 		// initialization of data structures
@@ -185,17 +185,17 @@ namespace Grawitas {
                     calculate_ids(parsed_talk_page, cur_id);
                     
                     // split by date if requested
-                    if(options.split_by_date) {
+                    if(options.split_by_date){
                         // get date for title
                         std::string dateToSplit;
                         try {
-                            dateToSplit = titleNDates.at(result.title);
+                            dateToSplit = titleNDates[result.title];
                         }
                         catch (const std::out_of_range&) {
                             dateToSplit = "01/01/2000";
                         }
                         
-                        Grawitas::export_finished_pages(output_folder, formats, result.title, parsed_talk_page, dateToSplit);
+                        export_finished_pages(output_folder, formats, result.title, parsed_talk_page, dateToSplit);
                     }
                     else {
                         

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -75,6 +75,12 @@ namespace {
 
 			if(boost::to_lower_copy(title.substr(0,5)) == "talk:")
 				title = title.substr(5);
+            
+            // removes any underscores
+            std::string delim = "_";
+            auto end = title.find(delim);
+            if (end != std::string::npos)
+                std::replace(title.begin(), title.end(), '_', ' ');
 		}
 	}	
 }
@@ -98,6 +104,7 @@ namespace Grawitas {
 			for(std::size_t i = 0; i < N_PAGES_PER_REQUEST; i++)
 			{
 				auto& page = page_progress[i % page_progress.size()];
+                //std::cout << "Page:" << page.first << "\n";
 				if(page.second == 0)
 					current_titles.push_back("Talk:" + page.first);
 				else
@@ -131,8 +138,8 @@ namespace Grawitas {
 			// parse every talk page and add it to partially_parsed_articles
 			for(const auto& result : results) 
 			{
-				if(result.missing || result.invalid)
-					continue; 
+				if(result.missing)
+					continue;
 
 				if(options.status_callback)
 					options.status_callback("Parsing '" + result.full_title + "'.");
@@ -145,14 +152,20 @@ namespace Grawitas {
 			// remove pages that returned missing from page_progress
 			for(const auto& result : results) 
 			{
-				if(!result.missing && !result.invalid)
+				if(!result.missing)
 					continue;
-
+                
 				// remove all remaining once from next_pages_to_crawl
-				page_progress.erase(std::remove_if(page_progress.begin(), page_progress.end(), [&result](const std::pair<std::string,int>& page) { 
+				page_progress.erase(std::remove_if(page_progress.begin(), page_progress.end(), [&result](const std::pair<std::string,int>& page) {
 					return page.first == result.title;
 				}), page_progress.end());
+                
+                // additional condition for when there is only one page remaining and it is a missing page 
+                if((page_progress.size() == 1))
+                    page_progress.clear();
+                
 			}
+            
 
 			// export those articles that are finished and remove them
 			for(const auto& result : results) 

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -122,7 +122,8 @@ namespace Grawitas {
 	{
                 
 		::sanitize_titles(article_titles);
-        ::sanitize_titles(titleNDates);
+        if(options.split_by_date)
+            ::sanitize_titles(titleNDates);
 		// initialization of data structures
 		std::map<std::string, std::vector<Grawitas::Comment>> partially_parsed_articles_map;
 		std::deque<std::pair<std::string, int>> page_progress;
@@ -221,7 +222,8 @@ namespace Grawitas {
                         catch (const std::out_of_range&) {
                             dateToSplit = "01/01/2000";
                         }
-                        options.status_callback("Finished all archives of '" + result.title + " after" + dateToSplit + "'. Exporting results.");
+                        if(options.status_callback)
+                            options.status_callback("Finished all archives of '" + result.title + " after" + dateToSplit + "'. Exporting results.");
                         export_finished_pages(output_folder, formats, result.title, parsed_talk_page, dateToSplit);
                     }
                     else {

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -194,7 +194,6 @@ namespace Grawitas {
                         catch (const std::out_of_range&) {
                             dateToSplit = "01/01/2000";
                         }
-                        
                         export_finished_pages(output_folder, formats, result.title, parsed_talk_page, dateToSplit);
                     }
                     else {

--- a/src/httpCrawler/crawling.cpp
+++ b/src/httpCrawler/crawling.cpp
@@ -131,7 +131,7 @@ namespace Grawitas {
 			// parse every talk page and add it to partially_parsed_articles
 			for(const auto& result : results) 
 			{
-				if(result.missing)
+				if(result.missing || result.invalid)
 					continue; 
 
 				if(options.status_callback)
@@ -145,7 +145,7 @@ namespace Grawitas {
 			// remove pages that returned missing from page_progress
 			for(const auto& result : results) 
 			{
-				if(!result.missing)
+				if(!result.missing && !result.invalid)
 					continue;
 
 				// remove all remaining once from next_pages_to_crawl

--- a/src/httpCrawler/crawling.h
+++ b/src/httpCrawler/crawling.h
@@ -17,10 +17,12 @@ namespace Grawitas {
 	struct AdditionalCrawlerOptions {
 		inline AdditionalCrawlerOptions()
 		:keep_raw_talk_pages(false),
+        split_by_date(false),
 		abort(nullptr)
 		{}
 
 		bool keep_raw_talk_pages;
+        bool split_by_date;
 		bool* abort;
 		std::function<void(const std::string&)> status_callback;
 	};

--- a/src/httpCrawler/crawling.h
+++ b/src/httpCrawler/crawling.h
@@ -27,5 +27,5 @@ namespace Grawitas {
 		std::function<void(const std::string&)> status_callback;
 	};
 
-	void crawling(std::vector<std::string> article_titles, const std::string& output_folder, const std::set<Grawitas::Format> formats, AdditionalCrawlerOptions options = AdditionalCrawlerOptions());
+	void crawling(std::vector<std::string> article_titles, std::map<std::string, std::string> titleNDates, const std::string& output_folder, const std::set<Grawitas::Format> formats, AdditionalCrawlerOptions options = AdditionalCrawlerOptions());
 }

--- a/src/httpCrawler/getPagesFromWikipedia.cpp
+++ b/src/httpCrawler/getPagesFromWikipedia.cpp
@@ -119,6 +119,7 @@ std::vector<TalkPageResult> get_pages_from_wikipedia(std::vector<std::string> pa
 		TalkPageResult result;
 		auto t = page.second;			
 		result.missing = t.count("missing");
+        result.invalid = t.count("invalid");
 		result.full_title = t.get<std::string>("title");
 
 		auto tmp = parse_page_title(result.full_title);
@@ -126,8 +127,9 @@ std::vector<TalkPageResult> get_pages_from_wikipedia(std::vector<std::string> pa
 		result.is_archive = std::get<1>(tmp);
 		result.i_archive = std::get<2>(tmp);
 
-		if(!result.missing)
+		if(!(result.missing && result.invalid))
 			result.content = t.get_child("revisions").front().second.get<std::string>("*");
+        
 
 		results.push_back(result);
 	}

--- a/src/httpCrawler/getPagesFromWikipedia.h
+++ b/src/httpCrawler/getPagesFromWikipedia.h
@@ -5,6 +5,7 @@
 
 struct TalkPageResult {
 	bool missing;
+    bool invalid; 
 	bool is_archive;
 	int i_archive;
 

--- a/src/httpCrawler/getPagesFromWikipedia.h
+++ b/src/httpCrawler/getPagesFromWikipedia.h
@@ -5,7 +5,6 @@
 
 struct TalkPageResult {
 	bool missing;
-    bool invalid; 
 	bool is_archive;
 	int i_archive;
 

--- a/src/misc/readLinesFromFile.cpp
+++ b/src/misc/readLinesFromFile.cpp
@@ -42,7 +42,8 @@ std::map<std::string, std::string> read_lines_dates_from_file(std:: istream& inp
         if (titleNDate.empty() || titleNDate.size() == 1){
             if (previousDate == "NULL"){
                 throw std::invalid_argument("Input talk page file does not contain any dates seperated for their titles seperated by a comma. Aborting.");
-            } else {
+            }
+            else{
                 titleNDate[1] = previousDate;
                 lines.insert(std::pair<std::string, std::string>(titleNDate[0], titleNDate[1]));
                 continue;

--- a/src/misc/readLinesFromFile.cpp
+++ b/src/misc/readLinesFromFile.cpp
@@ -23,41 +23,43 @@ std::map<std::string, std::string> read_lines_dates_from_file(std:: istream& inp
     std::string line;
     std::string previousDate = "NULL";
     
-    while(std::getline(input,line))
+    while(std::getline(input,line, '\n'))
     {
         // remove leading whitespaces and split string by comma
         boost::trim(line);
         
-        std::vector<std::string> titleNDate;
-        std::string segment;
+        std::pair<std::string, std::string> titleNDate;
         
         // convert line back to stringstream for getline
-        std::istringstream lineS(line);
-        while(std::getline(lineS, segment, ','))
-        {
-           // not sure if this will store Date in titleNDate
-           titleNDate.push_back(segment); // splits string at ',' character
+        int i = 0;
+        size_t pos = 0;
+        std::string delimiter = ",";
+        std::string title;
+        while((pos = line.find(delimiter)) != std::string::npos) {
+            title = line.substr(0, pos);
+            line.erase(0, pos + delimiter.length());
         }
-        
-        if (titleNDate.empty() || titleNDate.size() == 1){
+        titleNDate = std::make_pair(title, line);
+        if (titleNDate.first.empty()){
             if (previousDate == "NULL"){
                 throw std::invalid_argument("Input talk page file does not contain any dates seperated for their titles seperated by a comma. Aborting.");
             }
-            else{
-                titleNDate[1] = previousDate;
-                lines.insert(std::pair<std::string, std::string>(titleNDate[0], titleNDate[1]));
+            else {
+                // due to way string splitting works the title is stored in the date position
+                // if there is no date
+                titleNDate.first = titleNDate.second;
+                titleNDate.second = previousDate;
+                lines.insert(titleNDate);
                 continue;
             }
         }
         
-        if ((titleNDate[1].find('/') == std::string::npos) || (titleNDate[0].find('/') != std::string::npos)) {
-            // checks correct format
-            throw std::invalid_argument("Input talk page format should be 'title,dd/mm/yyyy'. Aborting.");
-        } else {
-            lines.insert(std::pair<std::string, std::string>(titleNDate[0], titleNDate[1]));
+        if (titleNDate.second.find('/') == std::string::npos || titleNDate.first.find('/') != std::string::npos) {
+             throw std::invalid_argument("Input talk page format should be 'title,dd/mm/yyyy'. Aborting.");
         }
-        
-        return lines;
+        lines.insert(titleNDate);
+        previousDate = titleNDate.second;
     }
+    return lines;
 }
 

--- a/src/misc/readLinesFromFile.cpp
+++ b/src/misc/readLinesFromFile.cpp
@@ -1,5 +1,7 @@
 #include "readLinesFromFile.h"
 #include <boost/algorithm/string/trim.hpp>
+#include <sstream>
+#include <iostream>
 
 std::vector<std::string> read_lines_from_file(std::istream& input)
 {
@@ -13,5 +15,48 @@ std::vector<std::string> read_lines_from_file(std::istream& input)
     }
 
 	return lines;
+}
+
+std::map<std::string, std::string> read_lines_dates_from_file(std:: istream& input)
+{
+    std::map<std::string, std::string> lines;
+    std::string line;
+    std::string previousDate = "NULL";
+    
+    while(std::getline(input,line))
+    {
+        // remove leading whitespaces and split string by comma
+        boost::trim(line);
+        
+        std::vector<std::string> titleNDate;
+        std::string segment;
+        
+        // convert line back to stringstream for getline
+        std::istringstream lineS(line);
+        while(std::getline(lineS, segment, ','))
+        {
+           // not sure if this will store Date in titleNDate
+           titleNDate.push_back(segment); // splits string at ',' character
+        }
+        
+        if (titleNDate.empty() || titleNDate.size() == 1){
+            if (previousDate == "NULL"){
+                throw std::invalid_argument("Input talk page file does not contain any dates seperated for their titles seperated by a comma. Aborting.");
+            } else {
+                titleNDate[1] = previousDate;
+                lines.insert(std::pair<std::string, std::string>(titleNDate[0], titleNDate[1]));
+                continue;
+            }
+        }
+        
+        if ((titleNDate[1].find('/') == std::string::npos) || (titleNDate[0].find('/') != std::string::npos)) {
+            // checks correct format
+            throw std::invalid_argument("Input talk page format should be 'title,dd/mm/yyyy'. Aborting.");
+        } else {
+            lines.insert(std::pair<std::string, std::string>(titleNDate[0], titleNDate[1]));
+        }
+        
+        return lines;
+    }
 }
 

--- a/src/misc/readLinesFromFile.h
+++ b/src/misc/readLinesFromFile.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <string>
+#include <map>
 #include <vector>
 #include <iostream>
 
 std::vector<std::string> read_lines_from_file(std::istream& input_file);
+std::map<std::string, std::string> read_lines_dates_from_file(std:: istream& input);

--- a/src/misc/splitByDate.cpp
+++ b/src/misc/splitByDate.cpp
@@ -3,20 +3,58 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <set>
 #include <iostream>
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
-namespace Grawitas {
 
-    void export_finished_pages(const std::string& output_folder, const std::set<Grawitas::Format> formats, const std::string& title, const std::vector<Grawitas::Comment>& parsed_talk_page, std::string dateToSplit)
-    {
+
+
+
+void export_finished_pages(const std::string& output_folder, const std::set<Grawitas::Format> formats, const std::string& title, const std::vector<Grawitas::Comment>& parsed_talk_page, const std::string& dateToSplit)
+{
         std::string title_filename = Grawitas::safeEncodeTitleToFilename(title);
+        std::string title_filename_after_date = Grawitas::safeEncodeTitleToFilename(title + "_after_" + dateToSplit);
+        
         std::map<Grawitas::Format, std::string> formats_with_paths;
         
-        /** ADD REST OF FUNC */
+        std::vector<Grawitas::Comment> before_date_comments = parsed_talk_page;
+        std::vector<Grawitas::Comment> after_date_comments;
         
+        for(auto& comment : before_date_comments) {
+            std::tm dateToCompare = boost::trim(comment.Date);
+            std::tm splitDate = 
             
-    
-    }
-
-
+            if((dateToCompare.substr(0,2) <= dateToSplit.substr(0,2)) && (dateToCompare.substr(3,5) <= dateToSplit.substr(3,5)) && (dateToCompare.substr(6,10) <= dateToCompare.substr(6,10))){
+                
+                continue;
+            }
+            else {
+                // add to data structure of talk page after the date
+                after_date_comments.push_back(comment);
+                
+                // delete this comment from 'before date' file
+                before_date_comments.erase(std::remove_if(before_date_comments.begin(), before_date_comments.end(), [&comment](const Grawitas::Comment& pageComment) {
+                    return comment.Id == pageComment.Id;
+                }), before_date_comments.end());
+            }
+            
+            }
+            
+        if(after_date_comments.size() == 0){
+            std::cout << "There are no comments made for " << title << " after this date: " << dateToSplit << ".\n";
+        }
+        else {
+            // export comments after date to file
+            for (const auto& format : formats){
+                formats_with_paths.insert({ format, output_folder + "/" + title_filename_after_date + Grawitas::FormatFileExtensions.at(format) });
+                Grawitas::output_in_formats_to_files(formats_with_paths, after_date_comments, {"id", "parent_id", "user", "date", "section", "text"});
+            }
+        }
+        for (const auto& format : formats){
+            formats_with_paths.insert({ format, output_folder + "/" + title_filename + Grawitas::FormatFileExtensions.at(format) });
+            Grawitas::output_in_formats_to_files(formats_with_paths, before_date_comments, {"id", "parent_id", "user", "date", "section", "text"});
+        }
+        
 }

--- a/src/misc/splitByDate.cpp
+++ b/src/misc/splitByDate.cpp
@@ -23,7 +23,7 @@ void export_finished_pages(const std::string& output_folder, const std::set<Graw
         std::string fileNameDate = dateToSplit;
         boost::erase_all(fileNameDate, "/");
         std::string title_filename_after_date = Grawitas::safeEncodeTitleToFilename(title + "_after_" + fileNameDate);
-        
+            
         std::map<Grawitas::Format, std::string> formats_with_paths;
         
         std::vector<Grawitas::Comment> before_date_comments;

--- a/src/misc/splitByDate.cpp
+++ b/src/misc/splitByDate.cpp
@@ -1,0 +1,22 @@
+#include "splitByDate.h"
+
+#include <string>
+#include <map>
+#include <vector>
+#include <iostream>
+
+namespace Grawitas {
+
+    void export_finished_pages(const std::string& output_folder, const std::set<Grawitas::Format> formats, const std::string& title, const std::vector<Grawitas::Comment>& parsed_talk_page, std::string dateToSplit)
+    {
+        std::string title_filename = Grawitas::safeEncodeTitleToFilename(title);
+        std::map<Grawitas::Format, std::string> formats_with_paths;
+        
+        /** ADD REST OF FUNC */
+        
+            
+    
+    }
+
+
+}

--- a/src/misc/splitByDate.h
+++ b/src/misc/splitByDate.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <vector>
+#include <iostream>
+
+
+namespace Grawitas {
+
+    void export_finished_pages(const std::string& output_folder, const std::set<Grawitas::Format> formats, const std::string& title, const std::vector<Grawitas::Comment>& parsed_talk_page, std::string dateToSplit);
+
+}
+
+
+

--- a/src/misc/splitByDate.h
+++ b/src/misc/splitByDate.h
@@ -3,14 +3,18 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <set>
 #include <iostream>
+#include "../talkPageParser/models.h"
+#include "../output/formats.h"
+#include "../output/outputWrapper.h"
+#include "../httpCrawler/getPagesFromWikipedia.h"
+#include "../talkPageParser/parsing.h"
 
 
-namespace Grawitas {
 
-    void export_finished_pages(const std::string& output_folder, const std::set<Grawitas::Format> formats, const std::string& title, const std::vector<Grawitas::Comment>& parsed_talk_page, std::string dateToSplit);
+void export_finished_pages(const std::string& output_folder, const std::set<Grawitas::Format> formats, const std::string& title, const std::vector<Grawitas::Comment>& parsed_talk_page, const std::string& dateToSplit);
 
-}
 
 
 

--- a/src/talkPageParser/date.cpp
+++ b/src/talkPageParser/date.cpp
@@ -30,3 +30,28 @@ bool operator==(const Grawitas::Date& d1, const Grawitas::Date& d2) {
 	);
 }
 
+bool operator>=(const Grawitas::Date& d1, const Grawitas::Date& d2) {
+    using namespace Grawitas;
+    if(get<YEAR>(d1) >= get<YEAR>(d2)) {
+        return true;
+    } else if(get<YEAR>(d1) == get<YEAR>(d2)) {
+        if(get<MONTH>(d1) >= get<MONTH>(d2)) {
+            return true;
+        } else if(get<MONTH>(d1) == get<MONTH>(d2)) {
+            if(get<DAY>(d1) >= get<DAY>(d2)) {
+                return true; 
+            } else if (get<DAY>(d1) == get<DAY>(d2)) {
+                return (get<HOUR>(d1) >= get<HOUR>(d2));
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    } else {
+        return false;
+    }
+    return true;
+}
+
+

--- a/src/talkPageParser/date.h
+++ b/src/talkPageParser/date.h
@@ -45,4 +45,4 @@ namespace Grawitas {
 }
 
 bool operator==(const Grawitas::Date& d1, const Grawitas::Date& d2);
-bool operator>=(const Grawitas::Date& d1, const Grawitas::Date& d2); 
+bool operator>=(const Grawitas::Date& d1, const Grawitas::Date& d2);

--- a/src/talkPageParser/date.h
+++ b/src/talkPageParser/date.h
@@ -45,3 +45,4 @@ namespace Grawitas {
 }
 
 bool operator==(const Grawitas::Date& d1, const Grawitas::Date& d2);
+bool operator>=(const Grawitas::Date& d1, const Grawitas::Date& d2); 


### PR DESCRIPTION
This fixes the handling of titles with underscores instead of spaces in the .txt file that cli_crawler takes as input. 

Originally any title with an underscore in it would cause the crawler to go into an infinite loop, trying to find non-existent archives for pages. 

I've added additional handling to the ``sanitize_titles`` in crawling.ccp method to remove the underscores.

Furthemore, I've added a simple error message using `` std::cout `` when an incorrect title is given in the .txt file so the user is aware such a file did not parse. 